### PR TITLE
update to n-api 6 (node 13.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 nodejs-sys
 ----------
 
-Bindings for NodeJS' [N-API](https://nodejs.org/dist/latest-v12.x/docs/api/n-api.html).
+Bindings for NodeJS' [N-API](https://nodejs.org/dist/latest-v13.x/docs/api/n-api.html).
 
 Requirements
 ============


### PR DESCRIPTION
Adds a bunch of new functions for threadsafe callbacks and `napi_get_all_property_names`, among others.

Needed for https://github.com/neon-bindings/neon/pull/493 :)